### PR TITLE
Define APPLICATION_HOST before configure block

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,7 +1,8 @@
+if ENV.fetch("HEROKU_APP_NAME", "").include?("staging-pr-")
+  ENV["APPLICATION_HOST"] = ENV["HEROKU_APP_NAME"] + ".herokuapp.com"
+end
+
 Rails.application.configure do
-  if ENV.fetch("HEROKU_APP_NAME", "").include?("staging-pr-")
-    ENV["APPLICATION_HOST"] = ENV["HEROKU_APP_NAME"] + ".herokuapp.com"
-  end
   config.middleware.use Rack::CanonicalHost, ENV.fetch("APPLICATION_HOST")
   config.cache_classes = true
   config.eager_load = true


### PR DESCRIPTION
This might fix Heroku build failures such as this one:
https://dashboard.heroku.com/apps/hon-graffiti/activity/builds/3d1121fb-d69b-4619-bcb3-fd3f2d164651
