### PR TITLE
Remove rb-readline gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ gem "title"
 gem "uglifier"
 
 group :development do
-  gem "rb-readline"
   gem "quiet_assets"
   gem "spring"
   gem "spring-commands-rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,7 +172,6 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (11.3.0)
-    rb-readline (0.5.3)
     recipient_interceptor (0.1.2)
       mail
     rspec-core (3.4.4)
@@ -284,7 +283,6 @@ DEPENDENCIES
   rack-timeout
   rails (~> 4.2.0)
   rails_stdout_logging
-  rb-readline
   recipient_interceptor
   rspec-rails (~> 3.4.0)
   sass-rails (~> 5.0)


### PR DESCRIPTION
The readline issue I was having persisted in spite of the rb-readline
gem and had to be resolved in my local dev environment. Therefore, as
far as I know there is no need for said gem.
